### PR TITLE
Fix length check after flush in UnreliableChannel

### DIFF
--- a/src/unreliable_channel.rs
+++ b/src/unreliable_channel.rs
@@ -66,10 +66,10 @@ where
         let start = self.out_packet.len();
         if self.out_packet.capacity() - start < msg.len() + 2 {
             self.flush().await?;
-        }
 
-        if self.out_packet.capacity() - start < msg.len() + 2 {
-            return Err(SendError::TooBig);
+            if self.out_packet.capacity() < msg.len() + 2 {
+                return Err(SendError::TooBig);
+            }
         }
 
         let mut len = [0; 2];


### PR DESCRIPTION
The length of the previously flushed packet was used to check the remaining length of the new packet, throwing a TooBig error even if the new packet can fit the message.

Instead just check the capacity of the new out_packet after a flush.