### PR TITLE
derived Clone and PartialEq to settings

### DIFF
--- a/src/message_channels.rs
+++ b/src/message_channels.rs
@@ -28,7 +28,7 @@ use crate::{
 // TODO: Message channels are currently always full-duplex, because the unreliable / reliable
 // channels backing them are always full-duplex.  We could add configuration to limit a channel to
 // send or receive only, and to error if the remote sends to a send-only channel.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MessageChannelSettings {
     pub channel: PacketChannel,
     pub channel_mode: MessageChannelMode,
@@ -40,7 +40,7 @@ pub struct MessageChannelSettings {
     pub packet_buffer_size: usize,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MessageChannelMode {
     Unreliable {
         settings: unreliable_channel::Settings,

--- a/src/reliable_channel.rs
+++ b/src/reliable_channel.rs
@@ -38,7 +38,7 @@ pub enum Error {
     Shutdown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Settings {
     /// The target outgoing bandwidth, in bytes / sec.
     ///

--- a/src/unreliable_channel.rs
+++ b/src/unreliable_channel.rs
@@ -38,7 +38,7 @@ pub enum RecvError {
     BadFormat,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Settings {
     /// The target outgoing bandwidth, in bytes / sec.
     pub bandwidth: u32,


### PR DESCRIPTION
Clone would make using MessageChannelSettings in specific kinds of
closures easier, while PartialEq would allow comparisons between
different types of message settings.